### PR TITLE
Playhead attributes method aaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage/
 
 # logs
 *.log
+
+# ignore agent.js
+samples/agent.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.1.0]
+
+- Playhead attribute added
+
 ## [0.1.0] -
 
 - First Version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-video-dash",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "New relic tracker for dash player",
   "main": "src/index.js",
   "scripts": {

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -84,6 +84,10 @@ export default class DashTracker extends nrvideo.VideoTracker {
     return this.player.preload();
   }
 
+  getPlayhead() {
+    return this.player.time() * 1000; // in milliseconds
+  }
+
   isMuted() {
     return this.player.isMuted();
   }


### PR DESCRIPTION
For dash tracker playhead method was not there. In this PR I have updated the playhead properties of Dash.js