### PR TITLE
chore: add explicit workflow permissions (CodeQL NR-560482)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests with Coverage

--- a/.github/workflows/use-shared-publish.yml
+++ b/.github/workflows/use-shared-publish.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     uses: newrelic/video-core-js/.github/workflows/npm-publish.yml@stable


### PR DESCRIPTION
Adds `permissions: contents: read` to `use-shared-publish.yml` and `test.yml` to satisfy CodeQL `actions/missing-workflow-permissions`. AWS S3/npm publish steps use repository secrets not GITHUB_TOKEN so there is no functional impact. Resolves NR-560482.