### PR TITLE
chore: remove stray empty heading from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 - Updated the bundled `@newrelic/video-core` dependency to v5.0.1, adding Japan (JP) region collector support for Vega/Fire TV tracking.
 
-# CHANGELOG
-
-### Update
-
 ## [5.0.0] - 2026-07-28
 
 ### Added


### PR DESCRIPTION
## Summary
- Removes a stray, empty `# CHANGELOG` / `### Update` heading pair sitting between the v5.0.1 and v5.0.0 entries — leftover from 2024/2025 commits, unrelated to the semantic-release-generated content, with no content under either heading.

Flagged separately from the release-notes/changelog format fix (#63).